### PR TITLE
PackageBlacklist isnt .json file.

### DIFF
--- a/modules/client/components/About.md
+++ b/modules/client/components/About.md
@@ -43,7 +43,7 @@ npmcdn is not affiliated with or supported by npm, Inc. in any way. Please do no
 
 ### Abuse
 
-npmcdn blacklists some packages to prevent abuse. If you find a malicious package on npm, please take a moment to add it to [our blacklist](https://github.com/mjackson/npmcdn/blob/master/modules/PackageBlacklist.json)!
+npmcdn blacklists some packages to prevent abuse. If you find a malicious package on npm, please take a moment to add it to [our blacklist](https://github.com/mjackson/npmcdn/blob/master/modules/PackageBlacklist.js)!
 
 ### Feedback
 


### PR DESCRIPTION
i could be missing something dumb, but also, wouldn't something like [`eviljsproject`](https://github.com/mjackson/npmcdn/blob/master/modules/PackageBlacklist.js#L2) be a more appropriate placeholder?